### PR TITLE
chore(attached): formalize the load of page when element is attached

### DIFF
--- a/dist/amd/pagination.js
+++ b/dist/amd/pagination.js
@@ -83,6 +83,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-binding', 'aurelia-t
         }
         this.repository = this.entityManager.getRepository(this.resource);
         this.updateRecordCount();
+        this.load(this.page);
       }
     }, {
       key: 'loadPrevious',

--- a/dist/commonjs/pagination.js
+++ b/dist/commonjs/pagination.js
@@ -90,6 +90,7 @@ var Pagination = (function () {
       }
       this.repository = this.entityManager.getRepository(this.resource);
       this.updateRecordCount();
+      this.load(this.page);
     }
   }, {
     key: 'loadPrevious',

--- a/dist/es6/pagination.js
+++ b/dist/es6/pagination.js
@@ -46,6 +46,7 @@ export class Pagination {
     }
     this.repository = this.entityManager.getRepository(this.resource);
     this.updateRecordCount();
+    this.load(this.page);
   }
 
   /**

--- a/dist/system/pagination.js
+++ b/dist/system/pagination.js
@@ -93,6 +93,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-binding', 'aurelia-tem
             }
             this.repository = this.entityManager.getRepository(this.resource);
             this.updateRecordCount();
+            this.load(this.page);
           }
         }, {
           key: 'loadPrevious',

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -46,6 +46,7 @@ export class Pagination {
     }
     this.repository = this.entityManager.getRepository(this.resource);
     this.updateRecordCount();
+    this.load(this.page);
   }
 
   /**


### PR DESCRIPTION
Formalize the load of page when element is attached so that it gets propagated to parent which need it to load their data (aka paginated and data-table).